### PR TITLE
pc - try allowing insecure actions as initial workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     services:
       db:
         image: postgres:11


### PR DESCRIPTION
In this PR, propose a quick and dirty (though specifically "not recommended") fix to the broken CI/CD pipeline.

The CI/CD pipeline via GitHub actions is currently broken because of a change made by GitHub to work around a security vulnerability, described here: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

The quick and dirty fix is to add this line into the workflow:

```yml
    env:
      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
```

But this is not recommended.  A better approach is to use something called [environment files](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files).    I'll work on  another PR (#322 ) that uses that technique; if we can get that working, we should merge that instead, and close this PR.

But in the meantime, we should merge either #321 or #322 first before anything else, to restore the CI/CD pipeline.

