### PR TITLE
pc - try using environment file instead of setting env values directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,15 @@ jobs:
         options: --entrypoint redis-server
 
     steps:
+      - name: Set Environment Variables
+        id: set_github_env
+        run: |
+          echo "DATABASE_URL=postgres://postgres:@localhost:5432/test" >> $GITHUB_ENV
+          echo "PGUSER=postgres" >> $GITHUB_ENV
+          echo "PGPASSWORD=postgres" >> $GITHUB_ENV
+          echo "REDIS_URL=redis://localhost:6379/0" >> $GITHUB_ENV
+          echo "RAILS_ENV=test" >> $GITHUB_ENV
+          echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> $GITHUB_ENV
       - uses: actions/checkout@v1
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1.31.1
@@ -47,13 +56,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cypress-
       - name: Build and run rails tests
-        env:
-          DATABASE_URL: postgres://postgres:@localhost:5432/test
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          REDIS_URL: redis://localhost:6379/0
-          RAILS_ENV: test
-          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        # env:
+          # DATABASE_URL: postgres://postgres:@localhost:5432/test
+          # PGUSER: postgres
+          # PGPASSWORD: postgres
+          # REDIS_URL: redis://localhost:6379/0
+          # RAILS_ENV: test
+          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
         run: |
           sudo apt-get -yqq install libpq-dev
           bundle config path vendor/bundle
@@ -72,13 +81,13 @@ jobs:
           start: bundle exec rails server -e test -p 5017
           wait-on: http://localhost:5017
           command:  yarn cypress run --project ./test
-        env:
-          DATABASE_URL: postgres://postgres:@localhost:5432/test
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          REDIS_URL: redis://localhost:6379/0
-          RAILS_ENV: test
-          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        # env:
+        #   DATABASE_URL: postgres://postgres:@localhost:5432/test
+        #   PGUSER: postgres
+        #   PGPASSWORD: postgres
+        #   REDIS_URL: redis://localhost:6379/0
+        #   RAILS_ENV: test
+        #   RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       - name: Store Cypress Screenshots on Failure
         uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> $GITHUB_ENV
       - uses: actions/checkout@v1
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.31.1
+        uses: ruby/setup-ruby@v1.66.1
         with:
           ruby-version: 2.6.5
       - uses: borales/actions-yarn@v2.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Fix watched files problem
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p 
       - name: Cypress run
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v2.9.5
         with:
           install: false
           build: npx cypress install
@@ -89,7 +89,7 @@ jobs:
         #   RAILS_ENV: test
         #   RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       - name: Store Cypress Screenshots on Failure
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: cypress-screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cypress-
       - name: Build and run rails tests
-        # env:
-          # DATABASE_URL: postgres://postgres:@localhost:5432/test
-          # PGUSER: postgres
-          # PGPASSWORD: postgres
-          # REDIS_URL: redis://localhost:6379/0
-          # RAILS_ENV: test
-          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
         run: |
           sudo apt-get -yqq install libpq-dev
           bundle config path vendor/bundle
@@ -81,13 +74,6 @@ jobs:
           start: bundle exec rails server -e test -p 5017
           wait-on: http://localhost:5017
           command:  yarn cypress run --project ./test
-        # env:
-        #   DATABASE_URL: postgres://postgres:@localhost:5432/test
-        #   PGUSER: postgres
-        #   PGPASSWORD: postgres
-        #   REDIS_URL: redis://localhost:6379/0
-        #   RAILS_ENV: test
-        #   RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       - name: Store Cypress Screenshots on Failure
         uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
In this PR, propose a quick and dirty (though specifically "not recommended") fix to the broken CI/CD pipeline.

The CI/CD pipeline via GitHub actions is currently broken because of a change made by GitHub to work around a security vulnerability, described here: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

The quick and dirty fix is to add this line into the workflow as done in #321 

```yml
    env:
      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
```

But this is not recommended.  A better approach is to use something called [environment files](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files).   This PR uses this approach.


We should merge either this PR or #321 first before anything else, to restore the CI/CD pipeline.

