### PR TITLE
Pc investigate bug with creating assignment repos

### DIFF
--- a/app/jobs/course/create_assignment_repos_job.rb
+++ b/app/jobs/course/create_assignment_repos_job.rb
@@ -31,18 +31,18 @@ class CreateAssignmentReposJob < CourseJob
         if !response.respond_to?(:data) || response.respond_to?(:errors)
           puts "CREATION ERROR for #{repo_name} for user #{roster_student.user.username} #{response.to_h}"
           @create_errors += 1
+        else
+          begin
+            new_repo_full_name = get_repo_name_and_create_record(response, roster_student)
+          rescue Exception => e
+            puts "DB ERROR with #{repo_name} for user #{roster_student.user.username} #{e}"
+            @db_errors += 1
+          end
         end
         retval = 1
       rescue Exception => e
         puts "CREATION ERROR with #{repo_name} for user #{roster_student.user.username} #{e}"
         @create_errors += 1
-      end
-
-      begin
-        new_repo_full_name = get_repo_name_and_create_record(response, roster_student)
-      rescue Exception => e
-        puts "DB ERROR with #{repo_name} for user #{roster_student.user.username} #{e}"
-        @db_errors += 1
       end
 
       begin

--- a/app/jobs/course/create_assignment_repos_job.rb
+++ b/app/jobs/course/create_assignment_repos_job.rb
@@ -8,8 +8,9 @@ class CreateAssignmentReposJob < CourseJob
       @permission_level = options[:permission_level].downcase
       @assignment_name = options[:assignment_name]
       @org_id = get_org_node_id
-      @errors = 0
-  
+      @create_errors = 0
+      @permission_errors = 0
+
       roster_students = @course.roster_students.to_a.select{ |rs|
         !rs.is_ta? && rs.user && rs.user.username
       }
@@ -18,7 +19,7 @@ class CreateAssignmentReposJob < CourseJob
           repo_name = "#{@assignment_name}-#{rs.user.username}" 
           repos_created += create_assignment_repo(repo_name, rs)
       end
-      error_message = (@errors == 0 ? "" : " with #{@errors} errors (see log)")
+      error_message = ( (@permission_errors + @create_errors) == 0 ) ? "" : " with #{@create_errors} create errors and #{@permission_errors} permission errors(see log)"
       "#{pluralize repos_created, "repository"} created for assignment #{@assignment_name} with student permission level #{@permission_level}. #{error_message}"
     end
   
@@ -26,15 +27,14 @@ class CreateAssignmentReposJob < CourseJob
       begin
         response = github_machine_user.post '/graphql', { query: create_assignment_repo_query(repo_name)}.to_json
         if !response.respond_to?(:data) || response.respond_to?(:errors)
-          puts "ERROR with #{repo_name} for user #{roster_student.user.username} #{response}"
-          @errors += 1
-          return 0
+          puts "ERROR creating #{repo_name} for user #{roster_student.user.username} #{sawyer_resource_to_json(response)}"
+          @create_errors += 1
         end
         new_repo_full_name = get_repo_name_and_create_record(response, roster_student)
         add_repository_contributor(repo_name,roster_student.user.username)
       rescue Exception => e
         puts "ERROR with #{repo_name} for user #{roster_student.user.username} #{e}"
-        @errors += 1
+        @permission_errors += 1
         return 0
       end
       1
@@ -88,5 +88,9 @@ class CreateAssignmentReposJob < CourseJob
           }
         }
       GRAPHQL
+    end
+
+    def sawyer_resource_to_json(sawyer_resource)
+      sawyer_resource.map(&:to_h).to_json
     end
   end

--- a/app/jobs/course/create_assignment_repos_job.rb
+++ b/app/jobs/course/create_assignment_repos_job.rb
@@ -1,68 +1,58 @@
 class CreateAssignmentReposJob < CourseJob
-    @job_name = "Create Assignment Repositories"
-    @job_short_name = "create_assignment_repos"
-    @job_description = "Creates a repository for the given assignment for each roster student"
-  
-    def attempt_job(options)
-      @visibility = options[:visibility].upcase
-      @permission_level = options[:permission_level].downcase
-      @assignment_name = options[:assignment_name]
-      @org_id = get_org_node_id
-      @create_errors = 0
-      @permission_errors = 0
-      @db_errors = 0
+  @job_name = "Create Assignment Repositories"
+  @job_short_name = "create_assignment_repos"
+  @job_description = "Creates a repository for the given assignment for each roster student"
 
-      roster_students = @course.roster_students.to_a.select{ |rs|
-        !rs.is_ta? && rs.user && rs.user.username
-      }
-      repos_created = 0
-      roster_students.each do |rs|
-          repo_name = "#{@assignment_name}-#{rs.user.username}" 
-          repos_created += create_assignment_repo(repo_name, rs)
-      end
-      error_message = ( (@permission_errors + @create_errors + @db_errors) == 0 ) ? "" : " with #{@create_errors} create errors, #{@permission_errors} permission errors, and  #{@db_errors} db errors (see log)"
-      "#{pluralize repos_created, "repository"} created for assignment #{@assignment_name} with student permission level #{@permission_level}. #{error_message}"
-    end
-  
-    def create_assignment_repo(repo_name, roster_student)
-      retval = 0
-      begin
-        response = github_machine_user.post '/graphql', { query: create_assignment_repo_query(repo_name)}.to_json
-        if !response.respond_to?(:data) || response.respond_to?(:errors)
-          puts "CREATION ERROR for #{repo_name} for user #{roster_student.user.username} #{response.to_h}"
-          @create_errors += 1
-        else
-          begin
-            new_repo_full_name = get_repo_name_and_create_record(response, roster_student)
-          rescue Exception => e
-            puts "DB ERROR with #{repo_name} for user #{roster_student.user.username} #{e}"
-            @db_errors += 1
-          end
-        end
-        retval = 1
-      rescue Exception => e
-        puts "CREATION ERROR with #{repo_name} for user #{roster_student.user.username} #{e}"
-        @create_errors += 1
-      end
+  def attempt_job(options)
+    @visibility = options[:visibility].upcase
+    @permission_level = options[:permission_level].downcase
+    @assignment_name = options[:assignment_name]
+    @org_id = get_org_node_id
+    
+    roster_students = @course.roster_students.to_a.select { |rs|
+      !rs.is_ta? && rs.user && rs.user.username
+    }
+    repos_created = 0
+    repos_updated = 0
 
-      begin
-        add_repository_contributor(repo_name,roster_student.user.username)
-      rescue Exception => e
-        puts "PERMISSION ERROR with #{repo_name} for user #{roster_student.user.username} #{e}"
-        @permission_errors += 1
-      end
-      retval
+    roster_students.each do |rs|
+      repo_name = "#{@assignment_name}-#{rs.user.username}"
+      repos_created += create_assignment_repo(repo_name, rs)
+      repos_updated += add_repository_contributor(repo_name, rs.user.username)
     end
-  
-    def add_repository_contributor(repo_name,username)
+    "For #{pluralize roster_students.length, "roster student"}, #{pluralize repos_created, "repository"} created and permissions updated for #{pluralize repos_updated, "repository"} for assignment #{@assignment_name} with student permission level #{@permission_level}"
+  end
+
+  def create_assignment_repo(repo_name, roster_student)
+    begin
+      response = github_machine_user.post "/graphql", { query: create_assignment_repo_query(repo_name) }.to_json
+      if !response.respond_to?(:data) || response.respond_to?(:errors)
+        puts "CREATION ERROR for #{repo_name} for user #{roster_student.user.username} #{response.to_h}"
+        return 0
+      end
+      new_repo_full_name = get_repo_name_and_create_record(response, roster_student)
+    rescue Exception => e
+      puts "CREATION ERROR with #{repo_name} for user #{roster_student.user.username} #{e}"
+      return 0
+    end
+    1
+  end
+
+  def add_repository_contributor(repo_name, username)
+    begin
       url = "/repos/#{@course.course_organization}/#{repo_name}/collaborators/#{username}"
       puts "\n\nadd_repository_contributor, url=#{url}"
-      result = github_machine_user.put(url, {"permission": "#{@permission_level}"});
+      result = github_machine_user.put(url, { "permission": "#{@permission_level}" })
       puts "\n\nadd_repository_contributor, result=#{result.to_json}"
+    rescue Exception => e
+      puts "PERMISSION ERROR with #{repo_name} for user #{roster_student.user.username} #{e}"
+      return 0
     end
+    1
+  end
 
-    def create_assignment_repo_query(repo_name)
-      <<-GRAPHQL
+  def create_assignment_repo_query(repo_name)
+    <<-GRAPHQL
         mutation {
           createRepository(input:{
             visibility: #{@visibility}
@@ -78,31 +68,29 @@ class CreateAssignmentReposJob < CourseJob
           }
         }
       GRAPHQL
-    end
-  
-    def get_repo_name_and_create_record(response, roster_student)
-      repoInfo = response.data.createRepository.repository
-  
-      new_repo = GithubRepo.create(name: repoInfo.name, url: repoInfo.url, full_name: repoInfo.nameWithOwner,
-                                course_id: @course.id, visibility: @visibility.downcase, repo_id: repoInfo.databaseId)
-      RepoContributor.create(user: roster_student.user, github_repo: new_repo, permission_level: @permission_level)
-      new_repo.full_name
-    end
-  
-    def get_org_node_id
-      response = github_machine_user.post '/graphql', { query: org_node_id_query }.to_json
-      response.data.organization.id
-    end
-  
-    def org_node_id_query
-      <<-GRAPHQL
+  end
+
+  def get_repo_name_and_create_record(response, roster_student)
+    repoInfo = response.data.createRepository.repository
+
+    new_repo = GithubRepo.create(name: repoInfo.name, url: repoInfo.url, full_name: repoInfo.nameWithOwner,
+                                 course_id: @course.id, visibility: @visibility.downcase, repo_id: repoInfo.databaseId)
+    RepoContributor.create(user: roster_student.user, github_repo: new_repo, permission_level: @permission_level)
+    new_repo.full_name
+  end
+
+  def get_org_node_id
+    response = github_machine_user.post "/graphql", { query: org_node_id_query }.to_json
+    response.data.organization.id
+  end
+
+  def org_node_id_query
+    <<-GRAPHQL
         query {
           organization(login:"#{@course.course_organization}") {
             id
           }
         }
       GRAPHQL
-    end
-
-   
   end
+end


### PR DESCRIPTION
In this PR, we add error handling and reporting for the job that creates assignment repos.

This job loops through all roster students for a course, and for each one:
* creates a repo
* adds that repo to the database
* adds the user as a contributor to the repo with admin privileges

Previously, if there was any error that throw an exception in any part of that, the entire job would fail.

Now, each of those is wrapped in error handling so that if it fails, the rest of the job can proceed.
We report the total number of roster students, the total number of repos created, and the total that had their permissions updated so that the user has more visibility into what is happening.

