### PR TITLE
Add a "term" field to Courses

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -199,7 +199,7 @@ class CoursesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def course_params
-      params.require(:course).permit(:name,:course_organization,:hidden, :search, :github_webhooks_enabled)
+      params.require(:course).permit(:name,:course_organization,:hidden, :search, :github_webhooks_enabled, :term)
     end
 
     def add_instructor(id)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,6 +6,7 @@ class Course < ApplicationRecord
   # validates :name,  presence: true,
   #                   length: { minimum: 3 }
   validates :name, presence: true, length: { minimum: 3 }, uniqueness: true
+  validates :term, presence: false
   validates :course_organization, presence: true, length: { minimum: 3 }, uniqueness: true
   validate :check_course_org_exists
   has_many :roster_students, dependent: :destroy

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -17,6 +17,11 @@
   </div>
 
   <div class="field">
+    <%= form.label :term %>
+    <%= form.text_field :term, id: :course_name %>
+  </div>
+
+  <div class="field">
     <%= form.label :course_organization %>
     <%= form.text_field :course_organization, id: :course_name %>
   </div>

--- a/db/migrate/20210329190634_add_term_to_courses.rb
+++ b/db/migrate/20210329190634_add_term_to_courses.rb
@@ -1,0 +1,5 @@
+class AddTermToCourses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :courses, :term, :string, null:true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_24_183703) do
+ActiveRecord::Schema.define(version: 2021_03_29_190634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2020_08_24_183703) do
     t.datetime "updated_at", null: false
     t.boolean "hidden"
     t.boolean "github_webhooks_enabled"
+    t.string "term"
   end
 
   create_table "flipper_features", force: :cascade do |t|
@@ -62,21 +63,7 @@ ActiveRecord::Schema.define(version: 2020_08_24_183703) do
     t.integer "repo_id"
     t.string "full_name"
     t.string "visibility"
-    t.boolean "is_project_repo"
     t.index ["course_id"], name: "index_github_repos_on_course_id"
-  end
-
-  create_table "informed_consents", force: :cascade do |t|
-    t.string "perm"
-    t.string "name"
-    t.bigint "course_id"
-    t.boolean "student_consents"
-    t.bigint "roster_student_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["course_id"], name: "index_informed_consents_on_course_id"
-    t.index ["perm", "course_id"], name: "index_informed_consents_on_perm_and_course_id", unique: true
-    t.index ["roster_student_id", "course_id"], name: "index_informed_consents_on_roster_student_id_and_course_id", unique: true
   end
 
   create_table "org_teams", force: :cascade do |t|
@@ -145,11 +132,6 @@ ActiveRecord::Schema.define(version: 2020_08_24_183703) do
     t.datetime "updated_at", null: false
     t.string "filenames_changed"
     t.boolean "committed_via_web"
-    t.string "author_login"
-    t.string "author_name"
-    t.string "author_email"
-    t.integer "additions"
-    t.integer "deletions"
     t.index ["github_repo_id"], name: "index_repo_commit_events_on_github_repo_id"
     t.index ["roster_student_id"], name: "index_repo_commit_events_on_roster_student_id"
   end
@@ -170,20 +152,6 @@ ActiveRecord::Schema.define(version: 2020_08_24_183703) do
     t.string "action_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "title"
-    t.string "body"
-    t.string "state"
-    t.boolean "closed"
-    t.datetime "closed_at"
-    t.integer "assignee_count"
-    t.string "assignee_logins"
-    t.string "assignee_names"
-    t.integer "project_card_count"
-    t.string "project_card_column_names"
-    t.string "project_card_column_project_names"
-    t.string "project_card_column_project_urls"
-    t.datetime "issue_created_at"
-    t.string "author_login"
     t.index ["github_repo_id"], name: "index_repo_issue_events_on_github_repo_id"
     t.index ["roster_student_id"], name: "index_repo_issue_events_on_roster_student_id"
   end

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -111,7 +111,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     stub_organization_membership_admin_in_org(course_organization, ENV["MACHINE_USER_NAME"])
     stub_organization_is_an_org(course_organization)
 
-    course = Course.create(name: "old course name", course_organization: course_organization, hidden: false)
+    course = Course.create(name: "old course name", term: "old course term", course_organization: course_organization, hidden: false)
     assert_nil Course.find_by(name: new_course_name)
 
     patch course_url(course), params: { course: { name: new_course_name } }
@@ -127,7 +127,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     stub_organization_membership_admin_in_org(course_organization, ENV["MACHINE_USER_NAME"])
     stub_organization_is_an_org(course_organization)
 
-    course = Course.create(term: "old course term", course_organization: course_organization, hidden: false)
+    course = Course.create(name: "old course name", term: "old course term", course_organization: course_organization, hidden: false)
     assert_nil Course.find_by(term: new_course_term)
 
     patch course_url(course), params: { course: { term: new_course_term } }

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -63,7 +63,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
   test "should create course" do
     stub_updating_org_membership("#{@org}")
     assert_difference('Course.count', 1) do
-      post courses_url, params: { course: { name: "blah", course_organization: "#{@org}" } }
+      post courses_url, params: { course: { name: "blah", term: "blah", course_organization: "#{@org}" } }
     end
 
     assert_redirected_to course_url(Course.last)

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -74,7 +74,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     fake_org_name = "not-a-real-org"
     stub_organization_does_not_exist(fake_org_name)
     assert_difference('Course.count', 0) do
-      post courses_url, params: { course: { name: "blah", course_organization: fake_org_name } }
+      post courses_url, params: { course: { name: "blah", term: "term", course_organization: fake_org_name } }
     end
 
     assert_response :ok
@@ -86,7 +86,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     stub_organization_is_an_org(org_name)
     stub_organization_exists_but_not_admin_in_org(org_name)
     assert_difference('Course.count', 0) do
-      post courses_url, params: {course: { name: "name", course_organization: org_name}}
+      post courses_url, params: {course: { name: "name", term: "term", course_organization: org_name}}
     end
 
     assert_response :ok
@@ -117,6 +117,22 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     patch course_url(course), params: { course: { name: new_course_name } }
 
     assert_not_nil Course.find_by(name: new_course_name)
+    assert_redirected_to course_url(course)
+  end
+
+  test "should update course term" do
+    new_course_term = 'new_course_term'
+    course_organization = "course_org"
+
+    stub_organization_membership_admin_in_org(course_organization, ENV["MACHINE_USER_NAME"])
+    stub_organization_is_an_org(course_organization)
+
+    course = Course.create(term: "old course term", course_organization: course_organization, hidden: false)
+    assert_nil Course.find_by(term: new_course_term)
+
+    patch course_url(course), params: { course: { term: new_course_term } }
+
+    assert_not_nil Course.find_by(term: new_course_term)
     assert_redirected_to course_url(course)
   end
 

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -63,10 +63,13 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
   test "should create course" do
     stub_updating_org_membership("#{@org}")
     assert_difference('Course.count', 1) do
-      post courses_url, params: { course: { name: "blah", term: "blah", course_organization: "#{@org}" } }
+      post courses_url, params: { course: { name: "blah", term: "blah_term", course_organization: "#{@org}" } }
     end
 
     assert_redirected_to course_url(Course.last)
+    assert_equal Course.last.name, "blah" 
+    assert_equal Course.last.term, "blah_term" 
+    assert_equal Course.last.course_organization, "#{@org}" 
   end
 
 


### PR DESCRIPTION
User Story: 

As an instructor setting up a new course, I can enter a "term" for the course so that users can find course instances more easily.

Acceptance Criteria:
- [x] An instructor can enter a term for a course when creating that course.
- [x] An instructor can edit the term for the course 


The "term" field is currently an optional string. This accommodates old courses without terms, and the wide variety in term naming systems used by different schools.