### PR TITLE
Add Schools table and associated CRUD action pages

### DIFF
--- a/app/assets/javascripts/schools.coffee
+++ b/app/assets/javascripts/schools.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/schools.scss
+++ b/app/assets/stylesheets/schools.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Schools controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,0 +1,74 @@
+class SchoolsController < ApplicationController
+  before_action :set_school, only: [:show, :edit, :update, :destroy]
+
+  # GET /schools
+  # GET /schools.json
+  def index
+    @schools = School.all
+  end
+
+  # GET /schools/1
+  # GET /schools/1.json
+  def show
+  end
+
+  # GET /schools/new
+  def new
+    @school = School.new
+  end
+
+  # GET /schools/1/edit
+  def edit
+  end
+
+  # POST /schools
+  # POST /schools.json
+  def create
+    @school = School.new(school_params)
+
+    respond_to do |format|
+      if @school.save
+        format.html { redirect_to @school, notice: 'School was successfully created.' }
+        format.json { render :show, status: :created, location: @school }
+      else
+        format.html { render :new }
+        format.json { render json: @school.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /schools/1
+  # PATCH/PUT /schools/1.json
+  def update
+    respond_to do |format|
+      if @school.update(school_params)
+        format.html { redirect_to @school, notice: 'School was successfully updated.' }
+        format.json { render :show, status: :ok, location: @school }
+      else
+        format.html { render :edit }
+        format.json { render json: @school.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /schools/1
+  # DELETE /schools/1.json
+  def destroy
+    @school.destroy
+    respond_to do |format|
+      format.html { redirect_to schools_url, notice: 'School was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_school
+      @school = School.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def school_params
+      params.require(:school).permit(:name, :abbreviation)
+    end
+end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,6 +1,7 @@
 class SchoolsController < ApplicationController
   before_action :set_school, only: [:show, :edit, :update, :destroy]
 
+  load_and_authorize_resource
   # GET /schools
   # GET /schools.json
   def index

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -1,0 +1,2 @@
+module SchoolsHelper
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,0 +1,2 @@
+class School < ApplicationRecord
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,5 +1,4 @@
 class School < ApplicationRecord
   validates :name, presence: true
   validates :abbreviation, presence: true
-  has_many :courses, dependent: :nullify
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,5 +1,5 @@
 class School < ApplicationRecord
   validates :name, presence: true
   validates :abbreviation, presence: true
-  has_many :courses
+  has_many :courses, dependent: :nullify
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,2 +1,5 @@
 class School < ApplicationRecord
+  validates :name, presence: true
+  validates :abbreviation, presence: true
+  has_many :courses
 end

--- a/app/views/layouts/schools.html.erb
+++ b/app/views/layouts/schools.html.erb
@@ -1,0 +1,4 @@
+<% content_for :main_content do %>
+  <%= yield %>
+<% end %>
+<%= render template: "layouts/application" %>

--- a/app/views/schools/_form.html.erb
+++ b/app/views/schools/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: school, local: true) do |form| %>
+  <% if school.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(school.errors.count, "error") %> prohibited this school from being saved:</h2>
+
+      <ul>
+      <% school.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :abbreviation %>
+    <%= form.text_field :abbreviation %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/schools/_school.json.jbuilder
+++ b/app/views/schools/_school.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! school, :id, :name, :abbreviation, :created_at, :updated_at
+json.url school_url(school, format: :json)

--- a/app/views/schools/edit.html.erb
+++ b/app/views/schools/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing School</h1>
+
+<%= render 'form', school: @school %>
+
+<%= link_to 'Show', @school %> |
+<%= link_to 'Back', schools_path %>

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Schools</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Abbreviation</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @schools.each do |school| %>
+      <tr>
+        <td><%= school.name %></td>
+        <td><%= school.abbreviation %></td>
+        <td><%= link_to 'Show', school %></td>
+        <td><%= link_to 'Edit', edit_school_path(school) %></td>
+        <td><%= link_to 'Destroy', school, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New School', new_school_path %>

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -2,27 +2,34 @@
 
 <h1>Schools</h1>
 
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Abbreviation</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <div class="panel-title">Schools</div>
+  </div>
+  <div class="panel-body">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Abbreviation</th>
+          <th colspan="3"></th>
+        </tr>
+      </thead>
 
-  <tbody>
-    <% @schools.each do |school| %>
-      <tr>
-        <td><%= school.name %></td>
-        <td><%= school.abbreviation %></td>
-        <td><%= link_to 'Show', school %></td>
-        <td><%= link_to 'Edit', edit_school_path(school) %></td>
-        <td><%= link_to 'Destroy', school, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+      <tbody>
+        <% @schools.each do |school| %>
+          <tr>
+            <td><%= school.name %></td>
+            <td><%= school.abbreviation %></td>
+            <td><%= link_to 'Show', school %></td>
+            <td><%= link_to 'Edit', edit_school_path(school) %></td>
+            <td><%= link_to 'Destroy', school, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
 
 <br>
 

--- a/app/views/schools/index.json.jbuilder
+++ b/app/views/schools/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @schools, partial: "schools/school", as: :school

--- a/app/views/schools/new.html.erb
+++ b/app/views/schools/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New School</h1>
+
+<%= render 'form', school: @school %>
+
+<%= link_to 'Back', schools_path %>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Name:</strong>
+  <%= @school.name %>
+</p>
+
+<p>
+  <strong>Abbreviation:</strong>
+  <%= @school.abbreviation %>
+</p>
+
+<%= link_to 'Edit', edit_school_path(@school) %> |
+<%= link_to 'Back', schools_path %>

--- a/app/views/schools/show.json.jbuilder
+++ b/app/views/schools/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "schools/school", school: @school

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :schools
   # resources :roster_students
   # devise routes
   devise_for :users, :controllers => {

--- a/db/migrate/20210415163631_create_schools.rb
+++ b/db/migrate/20210415163631_create_schools.rb
@@ -1,0 +1,10 @@
+class CreateSchools < ActiveRecord::Migration[5.2]
+  def change
+    create_table :schools do |t|
+      t.string :name
+      t.string :abbreviation
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,8 +34,6 @@ ActiveRecord::Schema.define(version: 2021_04_15_164332) do
     t.datetime "updated_at", null: false
     t.boolean "hidden"
     t.boolean "github_webhooks_enabled"
-    t.bigint "school_id"
-    t.index ["school_id"], name: "index_courses_on_school_id"
   end
 
   create_table "flipper_features", force: :cascade do |t|
@@ -281,7 +279,6 @@ ActiveRecord::Schema.define(version: 2021_04_15_164332) do
 
   add_foreign_key "completed_jobs", "courses"
   add_foreign_key "completed_jobs", "github_repos"
-  add_foreign_key "courses", "schools"
   add_foreign_key "github_repos", "courses"
   add_foreign_key "org_webhook_events", "courses"
   add_foreign_key "org_webhook_events", "github_repos"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_15_164332) do
+ActiveRecord::Schema.define(version: 2021_04_19_160808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,9 @@ ActiveRecord::Schema.define(version: 2021_04_15_164332) do
     t.datetime "updated_at", null: false
     t.boolean "hidden"
     t.boolean "github_webhooks_enabled"
+    t.string "term"
+    t.bigint "school_id"
+    t.index ["school_id"], name: "index_courses_on_school_id"
   end
 
   create_table "flipper_features", force: :cascade do |t|
@@ -279,6 +282,7 @@ ActiveRecord::Schema.define(version: 2021_04_15_164332) do
 
   add_foreign_key "completed_jobs", "courses"
   add_foreign_key "completed_jobs", "github_repos"
+  add_foreign_key "courses", "schools"
   add_foreign_key "github_repos", "courses"
   add_foreign_key "org_webhook_events", "courses"
   add_foreign_key "org_webhook_events", "github_repos"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_24_183703) do
+ActiveRecord::Schema.define(version: 2021_04_15_164332) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,8 @@ ActiveRecord::Schema.define(version: 2020_08_24_183703) do
     t.datetime "updated_at", null: false
     t.boolean "hidden"
     t.boolean "github_webhooks_enabled"
+    t.bigint "school_id"
+    t.index ["school_id"], name: "index_courses_on_school_id"
   end
 
   create_table "flipper_features", force: :cascade do |t|
@@ -62,21 +64,7 @@ ActiveRecord::Schema.define(version: 2020_08_24_183703) do
     t.integer "repo_id"
     t.string "full_name"
     t.string "visibility"
-    t.boolean "is_project_repo"
     t.index ["course_id"], name: "index_github_repos_on_course_id"
-  end
-
-  create_table "informed_consents", force: :cascade do |t|
-    t.string "perm"
-    t.string "name"
-    t.bigint "course_id"
-    t.boolean "student_consents"
-    t.bigint "roster_student_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["course_id"], name: "index_informed_consents_on_course_id"
-    t.index ["perm", "course_id"], name: "index_informed_consents_on_perm_and_course_id", unique: true
-    t.index ["roster_student_id", "course_id"], name: "index_informed_consents_on_roster_student_id_and_course_id", unique: true
   end
 
   create_table "org_teams", force: :cascade do |t|
@@ -145,11 +133,6 @@ ActiveRecord::Schema.define(version: 2020_08_24_183703) do
     t.datetime "updated_at", null: false
     t.string "filenames_changed"
     t.boolean "committed_via_web"
-    t.string "author_login"
-    t.string "author_name"
-    t.string "author_email"
-    t.integer "additions"
-    t.integer "deletions"
     t.index ["github_repo_id"], name: "index_repo_commit_events_on_github_repo_id"
     t.index ["roster_student_id"], name: "index_repo_commit_events_on_roster_student_id"
   end
@@ -170,20 +153,6 @@ ActiveRecord::Schema.define(version: 2020_08_24_183703) do
     t.string "action_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "title"
-    t.string "body"
-    t.string "state"
-    t.boolean "closed"
-    t.datetime "closed_at"
-    t.integer "assignee_count"
-    t.string "assignee_logins"
-    t.string "assignee_names"
-    t.integer "project_card_count"
-    t.string "project_card_column_names"
-    t.string "project_card_column_project_names"
-    t.string "project_card_column_project_urls"
-    t.datetime "issue_created_at"
-    t.string "author_login"
     t.index ["github_repo_id"], name: "index_repo_issue_events_on_github_repo_id"
     t.index ["roster_student_id"], name: "index_repo_issue_events_on_roster_student_id"
   end
@@ -238,6 +207,13 @@ ActiveRecord::Schema.define(version: 2020_08_24_183703) do
     t.index ["email", "course_id"], name: "index_roster_students_on_email_and_course_id", unique: true
     t.index ["perm", "course_id"], name: "index_roster_students_on_perm_and_course_id", unique: true
     t.index ["user_id"], name: "index_roster_students_on_user_id"
+  end
+
+  create_table "schools", force: :cascade do |t|
+    t.string "name"
+    t.string "abbreviation"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "slack_users", force: :cascade do |t|
@@ -305,6 +281,7 @@ ActiveRecord::Schema.define(version: 2020_08_24_183703) do
 
   add_foreign_key "completed_jobs", "courses"
   add_foreign_key "completed_jobs", "github_repos"
+  add_foreign_key "courses", "schools"
   add_foreign_key "github_repos", "courses"
   add_foreign_key "org_webhook_events", "courses"
   add_foreign_key "org_webhook_events", "github_repos"

--- a/test/controllers/schools_controller_test.rb
+++ b/test/controllers/schools_controller_test.rb
@@ -1,8 +1,12 @@
 require 'test_helper'
 
 class SchoolsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
   setup do
-    @school = schools(:one)
+    @school = schools(:ucsb)
+    @admin_user = users(:wes)
+    @admin_user.add_role(:admin)
+    sign_in @admin_user
   end
 
   test "should get index" do

--- a/test/controllers/schools_controller_test.rb
+++ b/test/controllers/schools_controller_test.rb
@@ -49,6 +49,24 @@ class SchoolsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to school_url(School.last)
   end
 
+  test "should not create school without name" do
+    assert_difference('School.count', 0) do
+      post schools_url, params: { school: { abbreviation: @school.abbreviation} }
+    end
+
+    assert_response :ok
+    assert_select 'div#error_explanation li', "Name can't be blank"
+  end
+
+  test "should not create school without abbreviation" do
+    assert_difference('School.count', 0) do
+      post schools_url, params: { school: { name: @school.name } }
+    end
+
+    assert_response :ok
+    assert_select 'div#error_explanation li', "Abbreviation can't be blank"
+  end
+
   test "should show school" do
     get school_url(@school)
     assert_response :success

--- a/test/controllers/schools_controller_test.rb
+++ b/test/controllers/schools_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class SchoolsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @school = schools(:one)
+  end
+
+  test "should get index" do
+    get schools_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_school_url
+    assert_response :success
+  end
+
+  test "should create school" do
+    assert_difference('School.count') do
+      post schools_url, params: { school: { abbreviation: @school.abbreviation, name: @school.name } }
+    end
+
+    assert_redirected_to school_url(School.last)
+  end
+
+  test "should show school" do
+    get school_url(@school)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_school_url(@school)
+    assert_response :success
+  end
+
+  test "should update school" do
+    patch school_url(@school), params: { school: { abbreviation: @school.abbreviation, name: @school.name } }
+    assert_redirected_to school_url(@school)
+  end
+
+  test "should destroy school" do
+    assert_difference('School.count', -1) do
+      delete school_url(@school)
+    end
+
+    assert_redirected_to schools_url
+  end
+end

--- a/test/controllers/schools_controller_test.rb
+++ b/test/controllers/schools_controller_test.rb
@@ -6,12 +6,20 @@ class SchoolsControllerTest < ActionDispatch::IntegrationTest
     @school = schools(:ucsb)
     @admin_user = users(:wes)
     @admin_user.add_role(:admin)
+    @user = users(:tim)
+
     sign_in @admin_user
   end
 
-  test "should get index" do
+  test "acces granted for schools index as admin" do
     get schools_url
     assert_response :success
+  end
+
+  test "acces denied for schools index" do
+    sign_in @user
+    get schools_url
+    assert_redirected_to root_path
   end
 
   test "should get new" do

--- a/test/controllers/schools_controller_test.rb
+++ b/test/controllers/schools_controller_test.rb
@@ -7,18 +7,32 @@ class SchoolsControllerTest < ActionDispatch::IntegrationTest
     @admin_user = users(:wes)
     @admin_user.add_role(:admin)
     @user = users(:tim)
+    @instructor_user = users(:julie)
+    @instructor_user.add_role(:instructor)
 
     sign_in @admin_user
   end
 
-  test "acces granted for schools index as admin" do
+  test "should ge schools index" do
     get schools_url
     assert_response :success
   end
 
-  test "acces denied for schools index" do
+  test "access denied for schools index" do
     sign_in @user
     get schools_url
+    assert_redirected_to root_path
+  end
+
+  test "access denied to instructors for schools index" do
+    sign_in @instructor_user
+    get schools_url
+    assert_redirected_to root_path
+  end
+
+  test "access denied for schools new" do
+    sign_in @user
+    get new_school_url
     assert_redirected_to root_path
   end
 

--- a/test/factories/schools.rb
+++ b/test/factories/schools.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :school do
+    name { "MyString" }
+    abbreviation { "MyString" }
+  end
+end

--- a/test/factories/schools.rb
+++ b/test/factories/schools.rb
@@ -1,6 +1,0 @@
-FactoryBot.define do
-  factory :school do
-    name { "MyString" }
-    abbreviation { "MyString" }
-  end
-end

--- a/test/fixtures/schools.yml
+++ b/test/fixtures/schools.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+ucsb:
+  name: University of California, Santa Barbara
+  abbreviation: UCSB
+
+wsu:
+  name: Washington State University
+  abbreviation: WSU

--- a/test/models/school_test.rb
+++ b/test/models/school_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SchoolTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/schools_test.rb
+++ b/test/system/schools_test.rb
@@ -1,0 +1,45 @@
+require "application_system_test_case"
+
+class SchoolsTest < ApplicationSystemTestCase
+  setup do
+    @school = schools(:one)
+  end
+
+  test "visiting the index" do
+    visit schools_url
+    assert_selector "h1", text: "Schools"
+  end
+
+  test "creating a School" do
+    visit schools_url
+    click_on "New School"
+
+    fill_in "Abbreviation", with: @school.abbreviation
+    fill_in "Name", with: @school.name
+    click_on "Create School"
+
+    assert_text "School was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a School" do
+    visit schools_url
+    click_on "Edit", match: :first
+
+    fill_in "Abbreviation", with: @school.abbreviation
+    fill_in "Name", with: @school.name
+    click_on "Update School"
+
+    assert_text "School was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a School" do
+    visit schools_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "School was successfully destroyed"
+  end
+end


### PR DESCRIPTION
This pull request creates a Schools table. Each School has two pieces of information: a name and an abbreviation. Administrators are permitted to create new schools, edit schools, and delete schools. This pull request does not expose or make this functionality visible in other elements of the UI; currently, it is only accessible from `/schools`.

Acceptance Criteria
- [ ] Adminstrators can view a table of schools
- [ ] Adminstrators can view & interact with pages that allow them to create, edit, and delete schools
- [ ] Instructors and other users are not permitted to take the previous two actions