### PR TITLE
pc/bh - a start at adjusting get commit job to respect course dates

### DIFF
--- a/app/jobs/repo/course_github_repo_get_commits.rb
+++ b/app/jobs/repo/course_github_repo_get_commits.rb
@@ -128,6 +128,18 @@ class CourseGithubRepoGetCommits < CourseGithubRepoJob
         else
           after_clause = ""
         end
+
+        # if there is a start and end date for the course, use it
+        # otherwise the since/until clause is empty
+
+        since_until_clause = ""
+
+        if ( @course.start_date != "" and @course.end_date != "")
+          start_date = @course.start_date.to_time.iso8601 # convert to correct format
+          end_date = @course.end_date.to_time.iso8601 # convert to correct format
+          since_until_clause = ", since: \"#{start_date}\", until: \"#{end_date}\""
+        end
+
         # Although the published limit on Graphql queries is 100,
         # in practice, we've found that it sometimes fails.
         # 50 seems to be safer round number.
@@ -139,7 +151,7 @@ class CourseGithubRepoGetCommits < CourseGithubRepoJob
                 target {
                   ... on Commit {
                     id
-                    history(first: 50 #{after_clause}) {
+                    history(first: 50 #{after_clause} #{since_until_clause}) {
                       pageInfo {
                         startCursor
                         hasNextPage

--- a/app/jobs/repo/course_github_repo_get_commits.rb
+++ b/app/jobs/repo/course_github_repo_get_commits.rb
@@ -133,8 +133,8 @@ class CourseGithubRepoGetCommits < CourseGithubRepoJob
         # otherwise the since/until clause is empty
 
         since_until_clause = ""
-
-        if ( @course.start_date != "" and @course.end_date != "")
+        
+        if ( (@course.start_date != nil) and (@course.end_date != nil) )
           start_date = @course.start_date.to_time.iso8601 # convert to correct format
           end_date = @course.end_date.to_time.iso8601 # convert to correct format
           since_until_clause = ", since: \"#{start_date}\", until: \"#{end_date}\""


### PR DESCRIPTION
In this draft PR, we modify the job to get commits for a project repo so that it only pulls commits that are within the start and end date of the course.

Brian's testing
With proper start date and end date:
![image](https://user-images.githubusercontent.com/58456542/122497207-e2ff5280-cfa1-11eb-81b8-afeedb3d8167.png)

With start date changed to a few days forward (same end date as before):
![image](https://user-images.githubusercontent.com/58456542/122497377-193cd200-cfa2-11eb-8003-e43dcccd3eaa.png)

No start date and end dates (before fix):
![image](https://user-images.githubusercontent.com/58456542/122497447-370a3700-cfa2-11eb-8abd-728eb2b8996f.png)

No start date and end dates (after fix):
![image](https://user-images.githubusercontent.com/58456542/122497474-412c3580-cfa2-11eb-82c1-946e247e3f67.png)



