### PR TITLE
pc - fix failing cypress test

### DIFF
--- a/app/javascript/components/Courses/CoursesIndex.jsx
+++ b/app/javascript/components/Courses/CoursesIndex.jsx
@@ -100,6 +100,7 @@ class CoursesIndex extends Component {
 				columns={this.columns}
 				data={this.state.courses}
 				keyField="id"
+				id="course_list"
 			/>
 
 			// <Fragment>


### PR DESCRIPTION
In this PR, we fix the failing cypress test on the branch vi-courses-react.

The cypress test is looking for the id `courses-table` to be on the table on the courses page.   This restores it.

Note: to run cypress tests locally:

1. Open two terminal windows, and cd into the root of the repo.
2. In the first, run the script `./cypress_server`
3. In the second, run the script `./cypress_run`
4. See the same results that you would get on CI.

