### PR TITLE
CSV Issue Downloads Now Include Issue Number

### DIFF
--- a/app/jobs/repo/course_github_repo_get_issues.rb
+++ b/app/jobs/repo/course_github_repo_get_issues.rb
@@ -112,6 +112,7 @@ class CourseGithubRepoGetIssues < CourseGithubRepoJob
     def update_one_issue(issue, i)
       begin
         issue.url =  i[:url]
+        issue.number = i[:number]
         issue.issue_id = i[:id]
         issue.github_repo = @github_repo
         issue.title = i[:title]

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -196,6 +196,7 @@ class GithubRepo < ApplicationRecord
       state
       done
       url
+      number
       github_repo_name
       github_repo_url
       github_repo_visibility
@@ -265,6 +266,7 @@ class GithubRepo < ApplicationRecord
       i.state,
       self.in_done_column(i),
       i.url,
+      i.number,
       repo.name,
       repo.url,
       repo.visibility,

--- a/db/migrate/20210629065128_add_number_to_repo_issue_event.rb
+++ b/db/migrate/20210629065128_add_number_to_repo_issue_event.rb
@@ -1,0 +1,5 @@
+class AddNumberToRepoIssueEvent < ActiveRecord::Migration[5.2]
+  def change
+    add_column :repo_issue_events, :number, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_27_190854) do
+ActiveRecord::Schema.define(version: 2021_06_29_065128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,9 +35,9 @@ ActiveRecord::Schema.define(version: 2021_05_27_190854) do
     t.boolean "hidden"
     t.boolean "github_webhooks_enabled"
     t.string "term"
+    t.bigint "school_id"
     t.datetime "start_date"
     t.datetime "end_date"
-    t.bigint "school_id"
     t.index ["school_id"], name: "index_courses_on_school_id"
   end
 
@@ -190,6 +190,7 @@ ActiveRecord::Schema.define(version: 2021_05_27_190854) do
     t.string "project_card_column_project_urls"
     t.datetime "issue_created_at"
     t.string "author_login"
+    t.integer "number"
     t.index ["github_repo_id"], name: "index_repo_issue_events_on_github_repo_id"
     t.index ["roster_student_id"], name: "index_repo_issue_events_on_roster_student_id"
   end


### PR DESCRIPTION
User Story: When downloading a CSV of issues from a repository or an organization, the resulting CSV includes an issue number column so that it can be filtered or sorted by issue number.

Addresses Issue #379.

Acceptance Criteria:
- [ ] Appropriately privileged users can download issue CSVs.
- [ ] Issue CSVs contain a 'number' column containing the unique issue number corresponding to the one in the URL.
- [ ] The above is true for both organization-wide and repository-specific downloads.