### PR TITLE
Fixed a line in job log code for readability

### DIFF
--- a/app/controllers/api/job_log_controller.rb
+++ b/app/controllers/api/job_log_controller.rb
@@ -3,7 +3,7 @@ module Api
     respond_to :json
     
     def index
-      joblog = CompletedJob.last_ten_jobs(params[:course_id],params[:github_repo_id])
+      joblog = CompletedJob.last_ten_jobs(nil,nil)
       render json: joblog
     end
   end


### PR DESCRIPTION
The api for job logs has multiple endpoints: one at the entire app level has no values for the parameters for course and repo.

Rather than passing these parameters (whose value will always be nil), it is likely better to write a line of code that shows them as nil.

Before

```
joblog = CompletedJob.last_ten_jobs(params[:course_id],params[:github_repo_id])
```

After:

```
      joblog = CompletedJob.last_ten_jobs(nil,nil)
```

This will not change functionality; just readability of the code.  The developer no longer has to "figure out" that these parameters will always be nil.