### PR TITLE
Refactored teams page to be a dropdown instead of a table

### DIFF
--- a/app/javascript/components/Course/Analytics/ChangeAnalytics.jsx
+++ b/app/javascript/components/Course/Analytics/ChangeAnalytics.jsx
@@ -33,6 +33,12 @@ class ChangeAnalytics extends Component {
         this.getProjectRepos(this.props.team)
     }
 
+    componentDidUpdate(prevProps, prevState) {
+        if (prevProps.team != this.props.team) {
+            this.getProjectRepos(this.props.team)
+        }
+    }
+
     getProjectRepos = (team) => {
         const response = fetch(`/api/courses/${team.org_team.course_id}/github_repos?is_project_repo=true`).then(response => response.json()).then(json => {
             if (json.length > 0) {

--- a/app/javascript/components/Course/Analytics/CommitsAnalytics.jsx
+++ b/app/javascript/components/Course/Analytics/CommitsAnalytics.jsx
@@ -32,6 +32,12 @@ class CommitsAnalytics extends Component {
     componentDidMount() {
         this.getProjectRepos(this.props.team)
     }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (prevProps.team != this.props.team) {
+            this.getProjectRepos(this.props.team)
+        }
+    }
     
     getProjectRepos = (team) => {
         const response = fetch(`/api/courses/${team.org_team.course_id}/github_repos?is_project_repo=true`).then(response => response.json()).then(json => {

--- a/app/javascript/components/Course/OrgTeams/CourseOrgTeam.jsx
+++ b/app/javascript/components/Course/OrgTeams/CourseOrgTeam.jsx
@@ -21,6 +21,12 @@ class CourseOrgTeam extends Component {
         this.fetchTeam();
     }
 
+    componentDidUpdate(prevProps, prevState) {
+        if (prevProps.org_team_id != this.props.org_team_id) {
+            this.fetchTeam();
+        }
+    }
+
     fetchTeam = () => {
         OrgTeamsService.getOrgTeam(this.props.course_id, this.props.org_team_id).then(
             (team) => {


### PR DESCRIPTION
In this PR, I refactored the github teams page to be a dropdown instead of a table. The user can select a team from a list of teams and the page will rerender to show information about that team directly on that page without leading to a show page.

Before:

![image](https://user-images.githubusercontent.com/1119017/127026221-8aa2963a-d543-4d6b-8fd0-e4fd1c99faa5.png)


After:

![image](https://user-images.githubusercontent.com/1119017/127026143-6b4dc673-a569-4bda-a0d5-352c7e0f62f1.png)
