### PR TITLE
at - add repo level job to the job list for pull requests' data 

### DIFF
--- a/app/controllers/courses/github_repos_controller.rb
+++ b/app/controllers/courses/github_repos_controller.rb
@@ -51,7 +51,7 @@ module Courses
       # @course = Course.find(params[:course_id])
       # @github_repo = GithubRepo.find(params[:id])
 
-      jobs = [CourseGithubRepoTestJob, CourseGithubRepoGetCommits, CourseGithubRepoGetIssues, CourseGithubRepoGetSDLCEvents]
+      jobs = [CourseGithubRepoTestJob, CourseGithubRepoGetCommits, CourseGithubRepoGetIssues,CourseGithubRepoGetPullRequests, CourseGithubRepoGetSDLCEvents]
       jobs
     end
     helper_method :course_github_repo_job_list

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,9 +35,9 @@ ActiveRecord::Schema.define(version: 2021_07_21_225059) do
     t.boolean "hidden"
     t.boolean "github_webhooks_enabled"
     t.string "term"
+    t.bigint "school_id"
     t.datetime "start_date"
     t.datetime "end_date"
-    t.bigint "school_id"
     t.index ["school_id"], name: "index_courses_on_school_id"
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,13 +1423,6 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@prettier/plugin-ruby@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@prettier/plugin-ruby/-/plugin-ruby-1.6.1.tgz#14489985513a72e052b57c1cf9beae288880faa8"
-  integrity sha512-PGDCATgVTQz0s/NB9nStiXVCIr+hG/XnKeAO/kguaHrNf8VwCpP5Ul+/KQao0z0QFBy2PDY8kWptfDQCa7WMXg==
-  dependencies:
-    prettier ">=1.10"
-
 "@rails/webpacker@4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-4.2.2.tgz#b9dd3235fdf4d0badbda8e33f6ebee742a9f3abb"
@@ -9977,11 +9970,6 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
-
-prettier@>=1.10:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
-  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 prettier@~2.2.1:
   version "2.2.1"


### PR DESCRIPTION
Apparently, this was a one line change - I missed to include the project repo level job to the job list

Before:  On a individual project repo, the "Get Pull Requests for this repo"  job is missing:

![image](https://user-images.githubusercontent.com/1119017/127534054-3b485c3b-cf2b-470e-b9ab-650813876a0e.png)


After:  The get PR data is there!

![image](https://user-images.githubusercontent.com/1119017/127534072-e714a74d-68d0-432c-b185-469f973585cb.png)
