### PR TITLE
Changed link for teams on student list to lead to team show page

### DIFF
--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -98,7 +98,7 @@
                 <td><%= student.org_membership_type.present? ? student.org_membership_type : "Non-member" %></td>
                 <td>
                   <% student.org_teams.each.with_index do |team, index| %>
-                    <%= link_to(team.name, team.url) + (", " unless index == student.org_teams.size - 1) %>
+                    <%= link_to(team.name, "/courses/" + team.course_id.to_s + "/org_teams/" + team.id.to_s) + (", " unless index == student.org_teams.size - 1) %>
                   <% end %>
                 </td>
                <td>


### PR DESCRIPTION
In this PR, I changed the link for "teams" on the student list to lead to the teams show page that includes more useful information, rather than leading the user to the teams github page.

Before:

This link led to the GitHub page for the team

![image](https://user-images.githubusercontent.com/1119017/127534630-691330a7-a3e5-4c05-b420-48e50ce2f1f9.png)

e.g. this (not the right team, but that's the general idea)

![image](https://user-images.githubusercontent.com/1119017/127534744-a555954c-ba42-4bda-9dd0-2abe7a6442a9.png)


After: it leads to the show page for the team:

![image](https://user-images.githubusercontent.com/1119017/127534822-2767439e-f668-4032-bb64-a22f9ee4250d.png)
