### PR TITLE
Added ability to associate a project repo to a team

### DIFF
--- a/app/controllers/api/courses/org_teams_controller.rb
+++ b/app/controllers/api/courses/org_teams_controller.rb
@@ -8,6 +8,16 @@ module Api::Courses
       respond_with @course.org_teams
     end
 
+    def update
+      @org_team = OrgTeam.find(params[:id])
+      @org_team.update_attributes(org_team_params)
+      @org_team.save
+    end
+
+    def org_team_params
+      params.require(:org_team).permit(:id, :name, :url, :course_id, :created_at, :updated_at, :team_id, :slug, :project_repo_id)
+    end
+
     def show
       members = @org_team.student_team_memberships.map{ |s| { 
           membership: s, 

--- a/app/javascript/components/Course/Analytics/ChangeAnalytics.jsx
+++ b/app/javascript/components/Course/Analytics/ChangeAnalytics.jsx
@@ -15,7 +15,7 @@ class ChangeAnalytics extends Component {
 
     constructor(props) {
         super(props);
-        this.state = {commitData: undefined, startDate: startDate, endDate: endDate, loading: false, repoId: undefined, repoTitle: undefined, projRepos: undefined};
+        this.state = {commitData: undefined, startDate: startDate, endDate: endDate, loading: false, repoTitle: undefined, projRepos: undefined};
         const startDate = new Date();
         startDate.setDate(startDate.getDate() - 30);
         const endDate = new Date();
@@ -37,16 +37,23 @@ class ChangeAnalytics extends Component {
         if (prevProps.team != this.props.team) {
             this.getProjectRepos(this.props.team)
         }
+
+        if (prevProps.project_repo_id != this.props.project_repo_id) {
+            this.setState({loading: true})
+            this.getProjectRepos(this.props.team)
+        }
     }
 
     getProjectRepos = (team) => {
-        const response = fetch(`/api/courses/${team.org_team.course_id}/github_repos?is_project_repo=true`).then(response => response.json()).then(json => {
-            if (json.length > 0) {
-                this.setState({repoId: json[0]["id"], repoTitle: json[0]["name"], projRepos: json})
-            }
-        }).then(response => {
+        if (this.props.project_repo_id != undefined) {
+            const response = fetch(`/api/courses/${team.org_team.course_id}/github_repos/${this.props.project_repo_id}`).then(response => response.json()).then(json => {
+                this.setState({ repoTitle: json["name"], projRepos: json})
+            }).then(response => {
+                this.getCommitData(this.props.team, undefined, undefined)
+            })
+        } else {
             this.getCommitData(this.props.team, undefined, undefined)
-        })
+        }
     }
 
     getCommitData = (team, startDate, endDate) => {
@@ -57,31 +64,39 @@ class ChangeAnalytics extends Component {
             commitDataDict[value.full_name] = null
         }
 
-        const response = fetch(`/api/courses/${team.org_team.course_id}/github_repos/${this.state.repoId}/repo_commit_events`).then(response => response.json()).then(json => {
-            console.log("json", json)
-            for (let i = 1; i < json.length; i++) {
-                if (json[i]["roster_student_id"] != null) {
-                    var student_name = json[i]["roster_student"]["first_name"] + " " + json[i]["roster_student"]["last_name"]
-                    if (student_name in commitDataDict) {
-                        if (startDate != undefined && endDate != undefined) {
-                            if (json[i]["commit_timestamp"] > startDate.toISOString() && json[i]["commit_timestamp"] < endDate.toISOString()) {
+        if (this.props.project_repo_id != undefined) {
+            const response = fetch(`/api/courses/${team.org_team.course_id}/github_repos/${this.props.project_repo_id}/repo_commit_events`).then(response => response.json()).then(json => {
+                console.log("json", json)
+                for (let i = 1; i < json.length; i++) {
+                    if (json[i]["roster_student_id"] != null) {
+                        var student_name = json[i]["roster_student"]["first_name"] + " " + json[i]["roster_student"]["last_name"]
+                        if (student_name in commitDataDict) {
+                            if (startDate != undefined && endDate != undefined) {
+                                if (json[i]["commit_timestamp"] > startDate.toISOString() && json[i]["commit_timestamp"] < endDate.toISOString()) {
+                                    commitDataDict[student_name] += json[i]["additions"]
+                                    commitDataDict[student_name] += json[i]["deletions"]
+                                }
+                            } else {
                                 commitDataDict[student_name] += json[i]["additions"]
                                 commitDataDict[student_name] += json[i]["deletions"]
                             }
-                        } else {
-                            commitDataDict[student_name] += json[i]["additions"]
-                            commitDataDict[student_name] += json[i]["deletions"]
                         }
                     }
                 }
-            }
 
+                if (this.checkProperties(commitDataDict)) {
+                    commitDataDict = {}
+                }
+
+                this.setState({commitData: commitDataDict, loading: false})
+            });
+        } else {
             if (this.checkProperties(commitDataDict)) {
                 commitDataDict = {}
             }
 
             this.setState({commitData: commitDataDict, loading: false})
-        });
+        }
     }
 
     onDateRangeChanged = (date, isStart) => {
@@ -101,22 +116,6 @@ class ChangeAnalytics extends Component {
         this.forceUpdate()
     }
 
-    onButtonClickGetRepo(repoName) {
-        this.setState({loading: true})
-        const response = fetch(`/api/courses/${this.props.course_id}/github_repos/`).then(response => response.json()).then(json => {
-            for (const [key, repo] of Object.entries(json)) {
-                if (repo["name"] == repoName) {
-                    this.setState({repoId: repo["id"], repoTitle: repo["name"]})
-
-                    this.getCommitData(this.props.team, this.state.startDate, this.state.endDate)
-                    this.forceUpdate()
-                }
-            }
-
-            this.setState({loading: false})
-        });
-    }
-
     render() {
         const commitData = this.state.commitData;
 
@@ -124,15 +123,6 @@ class ChangeAnalytics extends Component {
         
         return (
             <Fragment>
-                <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", padding: "0px", margin: "0px" }}>
-                    <ButtonToolbar>
-                        <DropdownButton title="Change Repo" id="dropdown-size-medium">
-                            {this.state.projRepos.map((object, index) => {
-                                return(<MenuItem key={object["name"]} onClick={() => this.onButtonClickGetRepo(object["name"])}>{object["name"]}</MenuItem>);
-                            })}
-                        </DropdownButton>
-                    </ButtonToolbar>
-                </div>
                 {this.state.repoTitle}
                 {this.state.loading && <Loader type="TailSpin" color="#00BFFF" height={80} width={80}/>}
                 {!this.state.loading && <ColumnChart data={commitData} width="900px" height="500px" empty="No Changes" colors={["red", "blue", "green", "yellow", "purple", "pink", "orange"]} disabled={this.state.loading}/>}
@@ -165,6 +155,7 @@ class ChangeAnalytics extends Component {
 
 ChangeAnalytics.propTypes = {
     team: PropTypes.object.isRequired,
+    project_repo_id: PropTypes.string,
 };
 
 export default ChangeAnalytics;

--- a/db/migrate/20210803074907_add_repo_id_to_org_team.rb
+++ b/db/migrate/20210803074907_add_repo_id_to_org_team.rb
@@ -1,0 +1,5 @@
+class AddRepoIdToOrgTeam < ActiveRecord::Migration[5.2]
+  def change
+    add_column :org_teams, :project_repo_id, :string, :null => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_21_225059) do
+ActiveRecord::Schema.define(version: 2021_08_03_074907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,9 +35,9 @@ ActiveRecord::Schema.define(version: 2021_07_21_225059) do
     t.boolean "hidden"
     t.boolean "github_webhooks_enabled"
     t.string "term"
-    t.bigint "school_id"
     t.datetime "start_date"
     t.datetime "end_date"
+    t.bigint "school_id"
     t.index ["school_id"], name: "index_courses_on_school_id"
   end
 
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 2021_07_21_225059) do
     t.datetime "updated_at", null: false
     t.string "team_id"
     t.string "slug"
+    t.string "project_repo_id"
     t.index ["course_id"], name: "index_org_teams_on_course_id"
   end
 


### PR DESCRIPTION
In this PR, I added a dropdown on each team page that allows the user to associate a team with a project repo. On change, the page will refresh all analytics to match the new project repo associated with the team.