### PR TITLE
pc - add 2 second delay to creating assignment repos

### DIFF
--- a/app/jobs/course/create_assignment_repos_job.rb
+++ b/app/jobs/course/create_assignment_repos_job.rb
@@ -20,7 +20,12 @@ class CreateAssignmentReposJob < CourseJob
       Rails.logger.info "Attempting to create: #{repo_name}"
       repos_created += create_assignment_repo(repo_name, rs)
       repos_updated += add_repository_contributor(repo_name, rs.user.username)
-      sleep 2
+      
+      if "#{ENV['SLEEP_TIME']}"
+        sleep_time = "#{ENV['SLEEP_TIME']}".to_i
+        Rails.logger.info "SLEEP_TIME set, sleeping #{sleep_time}"
+        sleep sleep_time
+      end
     end
     "For #{pluralize roster_students.length, "roster student"}, #{pluralize repos_created, "repository"} created and permissions updated for #{pluralize repos_updated, "repository"} for assignment #{@assignment_name} with student permission level #{@permission_level}"
   end

--- a/app/jobs/course/create_assignment_repos_job.rb
+++ b/app/jobs/course/create_assignment_repos_job.rb
@@ -17,8 +17,10 @@ class CreateAssignmentReposJob < CourseJob
 
     roster_students.each do |rs|
       repo_name = "#{@assignment_name}-#{rs.user.username}"
+      Rails.logger.info "Attempting to create: #{repo_name}"
       repos_created += create_assignment_repo(repo_name, rs)
       repos_updated += add_repository_contributor(repo_name, rs.user.username)
+      sleep 2
     end
     "For #{pluralize roster_students.length, "roster student"}, #{pluralize repos_created, "repository"} created and permissions updated for #{pluralize repos_updated, "repository"} for assignment #{@assignment_name} with student permission level #{@permission_level}"
   end

--- a/app/jobs/course/create_assignment_repos_job.rb
+++ b/app/jobs/course/create_assignment_repos_job.rb
@@ -20,14 +20,15 @@ class CreateAssignmentReposJob < CourseJob
       Rails.logger.info "Attempting to create: #{repo_name}"
       repos_created += create_assignment_repo(repo_name, rs)
       repos_updated += add_repository_contributor(repo_name, rs.user.username)
-      
+      summary = "For #{pluralize roster_students.length, "roster student"}, #{pluralize repos_created, "repository"} created and permissions updated for #{pluralize repos_updated, "repository"} for assignment #{@assignment_name} with student permission level #{@permission_level}"
+      update_job_record_with_completion_summary("In Progress.  So far: #{summary}")
       if "#{ENV['SLEEP_TIME']}"
         sleep_time = "#{ENV['SLEEP_TIME']}".to_i
         Rails.logger.info "SLEEP_TIME set, sleeping #{sleep_time}"
         sleep sleep_time
       end
     end
-    "For #{pluralize roster_students.length, "roster student"}, #{pluralize repos_created, "repository"} created and permissions updated for #{pluralize repos_updated, "repository"} for assignment #{@assignment_name} with student permission level #{@permission_level}"
+    "Done. For #{pluralize roster_students.length, "roster student"}, #{pluralize repos_created, "repository"} created and permissions updated for #{pluralize repos_updated, "repository"} for assignment #{@assignment_name} with student permission level #{@permission_level}"
   end
 
   def create_assignment_repo(repo_name, roster_student)


### PR DESCRIPTION
The job to create assignment repos was flaky--many repos were not created.

Root cause was determined to be these errors:

```
2021-11-03T20:18:00.848898+00:00 app[web.1]: CREATION ERROR for lab05-rmarangoly for user rmarangoly {:data=>{:createRepository=>nil}, :errors=>[{:type=>"RATE_LIMITED", :path=>["createRepository"], :locations=>[{:line=>2, :column=>11}], :message=>"You have created too many repositories, too quickly. Please try again later."}]}
```

Attempt to fix by adding a  delay (plus a Rails.logger.info so we can better track down assignment creation attempts and find the associated logging if/when debugging future problems.)

delay is configurable via environment variable `SLEEP_DELAY`

value is sleep time in seconds (converted to integer, and passed directly to ruby `sleep` )
