### PR TITLE
Remove mini_racer dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,6 @@ gem 'github_webhook', '~> 1.1'
 
 gem 'react_on_rails', '~> 11.3.0'
 gem 'webpacker', '~> 4'
-gem 'mini_racer', platforms: :ruby
 
 gem 'pg_search'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,9 +149,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
-    libv8 (8.4.255.0-x86_64-darwin-19)
-    libv8 (8.4.255.0-x86_64-darwin-20)
-    libv8 (8.4.255.0-x86_64-linux)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -167,13 +164,15 @@ GEM
     mimemagic (0.3.8)
       nokogiri (~> 1)
     mini_mime (1.0.2)
-    mini_racer (0.3.1)
-      libv8 (~> 8.4.255)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.5)
+    nokogiri (1.12.3)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     nokogiri (1.12.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.3-x86_64-linux)
@@ -343,6 +342,7 @@ GEM
     zlib (1.0.0)
 
 PLATFORMS
+  -darwin-21
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux
@@ -373,7 +373,6 @@ DEPENDENCIES
   kaminari
   listen (>= 3.0.5, < 3.2)
   loofah (~> 2.3.1)
-  mini_racer
   octokit (~> 4.18)
   omniauth
   omniauth-github
@@ -406,4 +405,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.19
+   2.3.13


### PR DESCRIPTION
This PR removes the unused `mini_racer` dependency, preventing issues with installing `libv8`.