### PR TITLE
Fix get course controller to return correct courses list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,6 @@ GEM
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
     libv8 (8.4.255.0-x86_64-darwin-19)
-    libv8 (8.4.255.0-x86_64-darwin-20)
     libv8 (8.4.255.0-x86_64-linux)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -343,6 +342,7 @@ GEM
     zlib (1.0.0)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux
@@ -406,4 +406,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.19
+   2.3.13

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
     libv8 (8.4.255.0-x86_64-darwin-19)
+    libv8 (8.4.255.0-x86_64-darwin-20)
     libv8 (8.4.255.0-x86_64-linux)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -342,7 +343,6 @@ GEM
     zlib (1.0.0)
 
 PLATFORMS
-  ruby
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux
@@ -406,4 +406,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.3.13
+   2.2.19

--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -4,6 +4,17 @@ module Api
     load_and_authorize_resource
     include Response
 
+    def index
+      if !current_user.has_role?(:admin)
+        @courses = Course.all.where(roster_students: current_user.roster_students)
+        if current_user.has_role?(:instructor)
+          @courses = [@courses.all, Course.with_role(:instructor, user=current_user).all].flatten.uniq
+        end
+      else
+        @courses = Course.all
+      end  
+    end
+
     def graphql
       @course = Course.find(params[:course_id])
       query = params[:query]
@@ -45,12 +56,6 @@ module Api
 
     def github_machine_user
       Octokit_Wrapper::Octokit_Wrapper.machine_user
-    end
-
-    respond_to :json
-    load_and_authorize_resource
-
-    def index
     end
 
   end

--- a/app/javascript/components/Courses/CoursesIndex.jsx
+++ b/app/javascript/components/Courses/CoursesIndex.jsx
@@ -28,15 +28,19 @@ class CoursesIndex extends Component {
 	};
 
 	 renderEditButton = (cell, row) => {
-		return (
-			<Button className="btn btn-warning" variant="warning" data-testid={`edit-button-${row.id}`} href={`${row.edit_path}`} >Edit</Button>
-		)
+		if(row.can_control){
+			return (
+				<Button className="btn btn-warning" variant="warning" data-testid={`edit-button-${row.id}`} href={`${row.edit_path}`} >Edit</Button>
+			)
+		}
 	}
 
 	 renderDeleteButton = (cell, row) => {
-		return (
-			<Button className="btn btn-danger" variant="danger" data-testid={`delete-button-${row.id}`} onClick={() => {if(window.confirm(`Delete course ${row.name}?`)) {this.deleteCourse(row)}}} >Delete</Button>
-		)
+		if(row.can_control){
+			return (
+				<Button className="btn btn-danger" variant="danger" data-testid={`delete-button-${row.id}`} onClick={() => {if(window.confirm(`Delete course ${row.name}?`)) {this.deleteCourse(row)}}} >Delete</Button>
+			)
+		}
 	}
 
 	 renderShowHideButton = (cell, row) => {
@@ -75,14 +79,12 @@ class CoursesIndex extends Component {
 			dataField: "edit",
 			text: "Edit",
 			isDummyField: true,
-			formatter: (cell, row) => this.renderEditButton(cell, row),
-			hidden: false /* should be true if this is not an instructor / admin */
+			formatter: (cell, row) => this.renderEditButton(cell, row)
 		}, {
 			dataField: "delete",
 			text: "Delete",
 			isDummyField: true,
-			formatter: (cell, row) => this.renderDeleteButton(cell, row),
-			hidden: false /* should be true if this is not an instructor / admin */
+			formatter: (cell, row) => this.renderDeleteButton(cell, row)
 		}
 	];
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -438,6 +438,18 @@ class Course < ApplicationRecord
     self.github_repos.where(is_project_repo: true)
   end
 
+  def instructor
+    Role.where(name: "instructor", resource_id: self.id).first.users.first
+  end
+
+  def is_instructor?(user)
+    user == instructor
+  end
+
+  def can_control?(user)
+    user.has_role?(:admin) || user == instructor
+  end
+
   def self.all_course_names
       Course.all.map{|c| c.name}
   end

--- a/app/views/api/courses/_course.json.jbuilder
+++ b/app/views/api/courses/_course.json.jbuilder
@@ -1,3 +1,4 @@
 json.extract! course, :id, :name, :course_organization, :created_at, :updated_at, :term, :school, :hidden
+json.can_control course.can_control?(current_user)
 json.path course_path(course)
 json.edit_path edit_course_path(course)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,9 +35,9 @@ ActiveRecord::Schema.define(version: 2021_08_03_074907) do
     t.boolean "hidden"
     t.boolean "github_webhooks_enabled"
     t.string "term"
+    t.bigint "school_id"
     t.datetime "start_date"
     t.datetime "end_date"
-    t.bigint "school_id"
     t.index ["school_id"], name: "index_courses_on_school_id"
   end
 

--- a/test/controllers/api/courses_controller_test.rb
+++ b/test/controllers/api/courses_controller_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+require 'helpers/octokit_stub_helper'
+
+class CoursesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+  include OctokitStubHelper
+
+  setup do
+    @course = courses(:course1)
+    @course2 = courses(:course2)
+    @user = users(:tim)
+    @roster_student = roster_students(:roster2)
+    sign_in @user
+  end
+
+#   test "should get index for student" do
+#     @user.remove_role(:admin)
+#     @user.add_role(:student)
+#     get "/api/courses/"
+#     assert_response :success
+#     assert_equal @course, @response.body
+#   end
+
+#   test "should get index for student instructor" do
+#     @user.add_role(:student)
+#     @user.add_role(:instructor)
+#     get "/api/courses/"
+#     assert_response :success
+#     assert_equal @course, @response.body
+#   end
+
+  test "should get index for admin" do
+    @user.add_role(:admin)
+    get "/api/courses"
+    assert_response :success
+    assert_equal [@course, @course2].to_json, @response.body
+  end
+
+end

--- a/test/controllers/api/courses_controller_test.rb
+++ b/test/controllers/api/courses_controller_test.rb
@@ -8,32 +8,61 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @course = courses(:course1)
     @course2 = courses(:course2)
-    @user = users(:tim)
-    @roster_student = roster_students(:roster2)
-    sign_in @user
   end
 
-#   test "should get index for student" do
-#     @user.remove_role(:admin)
-#     @user.add_role(:student)
-#     get "/api/courses/"
-#     assert_response :success
-#     assert_equal @course, @response.body
-#   end
+  test "should get index for student" do
+    studentUser = FactoryBot.create(:user, :student)
+    instructor = FactoryBot.create(:user, :instructor)
+    sign_in studentUser
+    newCourse = FactoryBot.create(:course, instructor: instructor)
+    FactoryBot.create(:roster_student, course: newCourse, user: studentUser)
+    get "/api/courses/"
+    assert_response :success
+    assert_equal newCourse.id, JSON.parse(response.body)[0]["id"]
+    assert_equal false, JSON.parse(response.body)[0]["can_control"]
+    assert_equal 1, JSON.parse(response.body).length
+  end
 
-#   test "should get index for student instructor" do
-#     @user.add_role(:student)
-#     @user.add_role(:instructor)
-#     get "/api/courses/"
-#     assert_response :success
-#     assert_equal @course, @response.body
-#   end
+  test "should get index for instructor" do
+    instructor = FactoryBot.create(:user, :instructor)
+    sign_in instructor
+    newCourse = FactoryBot.create(:course, instructor: instructor)
+    get "/api/courses/"
+    assert_response :success
+    assert_equal newCourse.id, JSON.parse(response.body)[0]["id"]
+    assert_equal true, JSON.parse(response.body)[0]["can_control"]
+    assert_equal 1, JSON.parse(response.body).length
+  end
+
+  test "should get index for student instructor" do
+    instructor = FactoryBot.create(:user, :instructor)
+    instructor2 = FactoryBot.create(:user, :instructor)
+    sign_in instructor
+    newCourse = FactoryBot.create(:course, instructor: instructor)
+    newCourse2 = FactoryBot.create(:course, instructor: instructor2)
+    FactoryBot.create(:roster_student, course: newCourse2, user: instructor)
+    get "/api/courses/"
+    assert_response :success
+    assert_equal newCourse2.id, JSON.parse(response.body)[0]["id"]
+    assert_equal false, JSON.parse(response.body)[0]["can_control"]
+    assert_equal newCourse.id, JSON.parse(response.body)[1]["id"]
+    assert_equal true, JSON.parse(response.body)[1]["can_control"]
+    assert_equal 2, JSON.parse(response.body).length
+  end
 
   test "should get index for admin" do
-    @user.add_role(:admin)
-    get "/api/courses"
+    adminUser = FactoryBot.create(:user, :admin)
+    instructor = FactoryBot.create(:user, :instructor)
+    sign_in adminUser 
+    FactoryBot.create(:role, resource_id: @course.id, users: [adminUser])
+    FactoryBot.create(:role, resource_id: @course2.id, users: [instructor])
+    get "/api/courses/"
     assert_response :success
-    assert_equal [@course, @course2].to_json, @response.body
+    assert_equal @course.id, JSON.parse(response.body)[0]["id"]
+    assert_equal true, JSON.parse(response.body)[1]["can_control"]
+    assert_equal @course2.id, JSON.parse(response.body)[1]["id"]
+    assert_equal true, JSON.parse(response.body)[1]["can_control"]
+    assert_equal 2, JSON.parse(response.body).length
   end
 
 end

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -5,6 +5,14 @@ FactoryBot.define do
             username {'student'}
             email {'student@example.org'}
         end
+        trait :instructor do
+            sequence(:name) { |n| "Instructor-#{n}" }
+            sequence(:username) { |n| "instructor-#{n}" }
+            sequence(:email) { |n| "instructor-#{n}@example.com" }
+            after(:build) do |user,_|
+                user.add_role(:instructor)
+            end
+        end
         trait :admin do
             name { 'Admin' }
             username {'admin'}
@@ -15,5 +23,31 @@ FactoryBot.define do
         end
         password { "123456" }
         sequence(:email) { |i| "user#{i}@example.org" }
+    end
+    factory :course do
+        to_create { |instance| instance.save(validate: false) }
+        name { 'test-course' }
+        course_organization { 'test-course-org' }
+        hidden { false }
+        transient do
+            instructor { FactoryBot.create(:user, :instructor) }
+        end
+        after(:create) do |course, evaluator|
+            FactoryBot.create(:role, resource_id: course.id, users: [evaluator.instructor])
+        end
+    end
+    factory :role do
+        name { 'instructor' }
+        resource_type { 'Course' }
+    end
+    factory :roster_student do
+        perm { 1234 }
+        first_name { 'Student' }
+        email { 'student@example.org' }
+        enrolled { false }
+        after(:build) do |roster_student, evaluator|
+            roster_student.course = evaluator.course
+            roster_student.user = evaluator.user
+        end
     end
 end 


### PR DESCRIPTION
Added check on the get courses api to return only student and instructor courses instead of all courses if a non-admin user is logged in. Also the edit and delete button is only shown on instructor courses or all courses if you're an admin. 