### PR TITLE
Sk show default member permissions

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -14,6 +14,7 @@ class CoursesController < ApplicationController
   # GET /courses/1
   # GET /courses/1.json
   def show
+    @default_member_permissions = @course.github_org_default_member_permissions
   end
 
   # # GET /courses/new

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -14,7 +14,7 @@ class CoursesController < ApplicationController
   # GET /courses/1
   # GET /courses/1.json
   def show
-    @default_member_permissions = @course.github_org_default_member_permissions
+    @default_member_permission = @course.github_org_default_member_permission
   end
 
   # # GET /courses/new

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -424,13 +424,8 @@ class Course < ApplicationRecord
 
   def github_org_default_member_permissions
     # look up course_organization and get the default membership permissions
-    # response = github_machine_user.post '/graphql', 
-    #            { query: github_user_graphql_query(github_username) }.to_json
-    # if !response.respond_to?(:data) || response.respond_to?(:errors)
-    #   return nil
-    # end   
-    # response
-    "to do"
+    response = github_machine_user.get "/orgs/#{course_organization}"
+    response.default_repository_permission
   end
 
   def github_user_graphql_query(github_username)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -422,10 +422,15 @@ class Course < ApplicationRecord
     response       
   end
 
-  def github_org_default_member_permissions
+  def github_org_default_member_permission
+    api_to_text = {"none": "No permission", "read": "Read", "write": "Write", "admin": "Admin"}
     # look up course_organization and get the default membership permissions
     response = github_machine_user.get "/orgs/#{course_organization}"
-    response.default_repository_permission
+    api_to_text[response.default_repository_permission.to_sym]
+  end
+
+  def github_org_change_default_member_permission_url
+    "https://github.com/organizations/#{course_organization}/settings/member_privileges"
   end
 
   def github_user_graphql_query(github_username)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -422,6 +422,17 @@ class Course < ApplicationRecord
     response       
   end
 
+  def github_org_default_member_permissions
+    # look up course_organization and get the default membership permissions
+    # response = github_machine_user.post '/graphql', 
+    #            { query: github_user_graphql_query(github_username) }.to_json
+    # if !response.respond_to?(:data) || response.respond_to?(:errors)
+    #   return nil
+    # end   
+    # response
+    "to do"
+  end
+
   def github_user_graphql_query(github_username)
     <<-GRAPHQL
     query { 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -423,10 +423,14 @@ class Course < ApplicationRecord
   end
 
   def github_org_default_member_permission
-    api_to_text = {"none": "No permission", "read": "Read", "write": "Write", "admin": "Admin"}
-    # look up course_organization and get the default membership permissions
-    response = github_machine_user.get "/orgs/#{course_organization}"
-    api_to_text[response.default_repository_permission.to_sym]
+    begin
+      api_to_text = {"none": "No permission", "read": "Read", "write": "Write", "admin": "Admin"}
+      # look up course_organization and get the default membership permissions
+      response = github_machine_user.get "/orgs/#{course_organization}"
+      api_to_text[response.default_repository_permission.to_sym]
+    rescue
+      "Unavailable"
+    end
   end
 
   def github_org_change_default_member_permission_url

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -11,6 +11,10 @@
     instructor. 
   <% end %>
 </p>
+<p>
+  Default member permissions: 
+  <%= @default_member_permissions %>
+</p>
 <%#= link_to "View Course Roster (#{@course.roster_students.length} enrolled)", course_roster_students_path(@course), class: "btn", role: "button" %>
 <div id="course-admin-panel" class="panel panel-default">
   <div class="panel-heading">

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -13,7 +13,13 @@
 </p>
 <p>
   Default member permissions: 
-  <%= @default_member_permissions %>
+  <strong><%= @default_member_permission %></strong>
+  <% if @default_member_permission == "No permission" %>
+    <span style="margin-left:2em;">This is the recommended value.</span>
+  <% else %>
+    <span style="margin-left:2em;" class="text-warning">Warning: the recommended value is "No permission".</span>
+  <% end %>
+  <%= link_to "Change default member permissions", @course.github_org_change_default_member_permission_url, class: "btn", role: "button" %>
 </p>
 <%#= link_to "View Course Roster (#{@course.roster_students.length} enrolled)", course_roster_students_path(@course), class: "btn", role: "button" %>
 <div id="course-admin-panel" class="panel panel-default">

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -15,6 +15,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
     stub_organization_membership_admin_in_org(@org, ENV["MACHINE_USER_NAME"])
     stub_organization_is_an_org(@org)
+    
     @enroll_success_flash_notice = %Q[You were successfully invited to #{@course.name}! View and accept your invitation <a href="https://github.com/orgs/#{@course.course_organization}/invitation">here</a>.]
   end
 
@@ -98,6 +99,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show course" do
+    stub_get_org_default_membership_permission(@course.course_organization)
     get course_url(@course)
     assert_response :success
   end
@@ -395,6 +397,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
 
 
   test "TAs should be able to view courses that they are TA of" do
+    stub_get_org_default_membership_permission(@course.course_organization)
     @user = users(:julie)
     @user.add_role :user
     @user.add_role :ta, @course
@@ -405,6 +408,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "TAs should not be able to view other courses they are not the TA of " do
+    stub_get_org_default_membership_permission(@course.course_organization)
     @user = users(:julie)
     @user.add_role :user
     @user.add_role :ta, @course

--- a/test/helpers/octokit_stub_helper.rb
+++ b/test/helpers/octokit_stub_helper.rb
@@ -130,6 +130,18 @@ module OctokitStubHelper
 
   end
 
+  def stub_get_org_default_membership_permission(org_name)
+      stub_request(:get, "https://api.github.com/orgs/#{org_name}").
+      with(
+      headers: {
+            'Accept'=>'application/vnd.github.v3+json',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type'=>'application/json',
+            'User-Agent'=>'Octokit Ruby Gem 4.18.0'
+      }).
+    to_return(status: 200, body: "{\"default_membership_permission\":\"none\"}", headers: {})
+  end
+
   def stub_organization_exists_but_not_admin_in_org(org_name)
     stub_request(:get, "https://api.github.com/user/memberships/orgs/#{org_name}").
       with(  headers: {


### PR DESCRIPTION
Closes #510 

In this PR, we add the ability for instructors to see current default member permissions for a course organization.
We also provide a warning if it is not the recommended value and a link to the place to change it.

<img width="812" alt="Screen Shot 2022-06-30 at 11 24 31 AM" src="https://user-images.githubusercontent.com/72824248/176750675-0377600c-b1d8-49b6-af4a-0f647d19d03f.png">

<img width="861" alt="Screen Shot 2022-06-30 at 11 25 01 AM" src="https://user-images.githubusercontent.com/72824248/176750781-b901bb45-c633-4a3a-b200-c26f44323950.png">

The link takes you directly to the github settings page where the permissions can be changed.
