### PR TITLE
as-added a new join page instead of a alert to accept the invitation when joining a course for a student

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -95,7 +95,6 @@ class CoursesController < ApplicationController
        @course.invite_user_to_course_org(current_user)
        roster_student.update_attribute(:enrolled, true)
        current_user.roster_students.push(roster_student)
-     #  redirect_to courses_path, notice: %Q[You were successfully invited to #{@course.name}! View and accept your invitation <a href="https://github.com/orgs/#{@course.course_organization}/invitation">here</a>.]
     rescue Exception => e
       message = "Unable to invite #{current_user.username} to #{@course.course_organization}; check whether #{ENV['MACHINE_USER_NAME']} has admin permission on that org.   Error: #{e.message}"
       redirect_to courses_path, alert: message

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -83,21 +83,21 @@ class CoursesController < ApplicationController
   end
 
   def join
-    course = Course.find(params[:course_id])
+    @course = Course.find(params[:course_id])
     # roster_student = course.roster_students.find_by(email: current_user.email)
-    roster_student = cross_check_user_emails_with_class(course)
+    roster_student = cross_check_user_emails_with_class(@course)
     if roster_student.nil?
       message = 'Your email did not match the email of any student on the course roster. Please check that your github email is correctly configured to match your school email and that you have verified your email address. '
       return redirect_to courses_path, alert: message
     end
 
     begin
-       course.invite_user_to_course_org(current_user)
+       @course.invite_user_to_course_org(current_user)
        roster_student.update_attribute(:enrolled, true)
        current_user.roster_students.push(roster_student)
-       redirect_to courses_path, notice: %Q[You were successfully invited to #{course.name}! View and accept your invitation <a href="https://github.com/orgs/#{course.course_organization}/invitation">here</a>.]
+     #  redirect_to courses_path, notice: %Q[You were successfully invited to #{@course.name}! View and accept your invitation <a href="https://github.com/orgs/#{@course.course_organization}/invitation">here</a>.]
     rescue Exception => e
-      message = "Unable to invite #{current_user.username} to #{course.course_organization}; check whether #{ENV['MACHINE_USER_NAME']} has admin permission on that org.   Error: #{e.message}"
+      message = "Unable to invite #{current_user.username} to #{@course.course_organization}; check whether #{ENV['MACHINE_USER_NAME']} has admin permission on that org.   Error: #{e.message}"
       redirect_to courses_path, alert: message
     end
   end

--- a/app/javascript/components/Course/JoinPage.jsx
+++ b/app/javascript/components/Course/JoinPage.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Panel } from "react-bootstrap";
+
+const JoinPage = ({current_path, course }) => {
+    const url = `https://github.com/orgs/${course.course_organization}/invitation`
+    return (
+        <Panel bsStyle="info" style={{marginTop: "3em"}}>
+        <Panel.Heading>
+          <Panel.Title componentClass="h3">Your Next Step</Panel.Title>
+        </Panel.Heading>
+        <Panel.Body>
+            <p>You were successfully invited to {course.name}! </p>
+            <p> <strong>Now please view and accept your invitation at the following link: </strong> </p>
+            <p style={{marginLeft: "2em"}}> <a href={url}>{url}</a></p>
+            <p> You are not successfully added to the course until you accept the invitation</p>
+        </Panel.Body>
+      </Panel>
+    );
+};
+
+
+
+export default JoinPage;

--- a/app/javascript/packs/react-bundle.js
+++ b/app/javascript/packs/react-bundle.js
@@ -14,7 +14,7 @@ import CourseOrgTeamsIndex from "../components/Course/OrgTeams/CourseOrgTeamsInd
 
 import JobLauncher from "../components/Jobs/JobLauncher";
 import JobLog from "../components/Jobs/JobLog";
-
+import JoinPage from '../components/Course/JoinPage';
 import SchoolsIndex from "../components/Schools/SchoolsIndex";
 import HomePage from "../components/home/HomePage";
 
@@ -43,6 +43,7 @@ ReactOnRails.register({
   CourseOrgTeamsIndex,
   JobLauncher,
   JobLog,
+  JoinPage,
   SchoolsIndex,
   HomePage,
   ExternalReposPage

--- a/app/javascript/stories/Course/JoinPage.stories.mdx
+++ b/app/javascript/stories/Course/JoinPage.stories.mdx
@@ -1,0 +1,24 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import JoinPage from '../../components/Course/JoinPage';
+import { BrowserRouter } from "react-router-dom";
+import { createMemoryHistory } from "history";
+
+
+<Meta title="components/Course/JoinPage" component={JoinPage} />
+
+# JoinPage
+
+The `JoinPage` appears when a user joins a course.
+
+export const Template = (args) => {
+  return (
+      <JoinPage {...args} />
+  )
+}
+
+<Canvas>
+  <Story name="Example" args={{ label: 'Example', course: {name: "test123", course_organization: "test123"} }}>
+    {Template.bind({})}
+   </Story>
+</Canvas>
+

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -454,7 +454,8 @@ class Course < ApplicationRecord
   end
 
   def instructor
-    Role.where(name: "instructor", resource_id: self.id).first.users.first
+    role = Role.where(name: "instructor", resource_id: self.id).first
+    role.nil? ? nil : role.users.first
   end
 
   def is_instructor?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,10 @@ class User < ApplicationRecord
     course_names = courses.map{|c| c.name}
     course_names.include?(course_name)
   end
+  
+  def instructor_of?(course)
+    course.instructor == self
+  end
 
   def courses_administrating
     if has_role? :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,9 +81,9 @@ class User < ApplicationRecord
     course_names = courses.map{|c| c.name}
     course_names.include?(course_name)
   end
-  
+
   def instructor_of?(course)
-    course.instructor == self
+    course && course.instructor == self
   end
 
   def courses_administrating

--- a/app/views/courses/_show_student.html.erb
+++ b/app/views/courses/_show_student.html.erb
@@ -1,0 +1,1 @@
+<p>Student Features Coming Soon </p>

--- a/app/views/courses/join.html.erb
+++ b/app/views/courses/join.html.erb
@@ -1,0 +1,8 @@
+
+<%= react_component("JoinPage",
+                        props: {current_path: request.env['PATH_INFO'],
+                                course: @course
+                        },
+                        prerender: false)
+%>
+

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -3,13 +3,3 @@
 <% elsif current_user.can? :show, @course %>
   <%= render 'show_student', course: Course.new %>
 <% end %>
-
-<!-- 
-<p>
-  <strong>Name:</strong>
-  <%= @course.name %>
-</p>
-
-<%= link_to 'Edit', edit_course_path(@course) %> |
-<%= link_to 'Back', courses_path %>
--->

--- a/app/views/layouts/courses.html.erb
+++ b/app/views/layouts/courses.html.erb
@@ -1,27 +1,29 @@
 <% content_for :main_content do %>
   <% if @course.present? && @course.id.present? %>
     <h1> <%= link_to @course.name, course_path(@course) %> </h1>
-    <%= react_component("CourseNavBar",
-                        props: {current_path: request.env['PATH_INFO'], roster_path: course_path(@course),
-                                project_teams_path: course_project_teams_path(@course), org_teams_path: course_org_teams_path(@course),
-                                repos_path: course_repos_path(@course),
-                                create_assignment_repos_path: course_create_repos_path(@course),
-                                project_repos_path: course_project_repos_path(@course),
-                                external_repos_path: external_course_github_repos_path(@course),
-                                slack_path: course_slack_path(@course),
-                                jobs_path: course_jobs_path(@course), edit_path: edit_course_path(@course),
-                                consent_path: course_informed_consents_path(@course),
-                                create_team_repos_path: create_repos_course_org_teams_path(@course),
-                                create_teams_path: create_teams_course_org_teams_path(@course), events_path: course_events_path(@course),
-                                can_edit: can?(:update, @course),
-                                github_repos_path: course_github_repos_path(@course),
-                                orphan_commits_path: course_orphan_commits_path(@course),
-                                download_commits_path: course_commits_path(@course, :format => "csv"),
-                                download_issues_path: course_issues_path(@course, :format => "csv"),
-                                download_pull_requests_path: course_pull_requests_path(@course, :format => "csv"),
-                        },
-                        prerender: false) %>
-    <br/>
+    <% if (current_user.has_role? :admin) || (current_user.instructor_of? @course) %>
+      <%= react_component("CourseNavBar",
+                          props: {current_path: request.env['PATH_INFO'], roster_path: course_path(@course),
+                                  project_teams_path: course_project_teams_path(@course), org_teams_path: course_org_teams_path(@course),
+                                  repos_path: course_repos_path(@course),
+                                  create_assignment_repos_path: course_create_repos_path(@course),
+                                  project_repos_path: course_project_repos_path(@course),
+                                  external_repos_path: external_course_github_repos_path(@course),
+                                  slack_path: course_slack_path(@course),
+                                  jobs_path: course_jobs_path(@course), edit_path: edit_course_path(@course),
+                                  consent_path: course_informed_consents_path(@course),
+                                  create_team_repos_path: create_repos_course_org_teams_path(@course),
+                                  create_teams_path: create_teams_course_org_teams_path(@course), events_path: course_events_path(@course),
+                                  can_edit: can?(:update, @course),
+                                  github_repos_path: course_github_repos_path(@course),
+                                  orphan_commits_path: course_orphan_commits_path(@course),
+                                  download_commits_path: course_commits_path(@course, :format => "csv"),
+                                  download_issues_path: course_issues_path(@course, :format => "csv"),
+                                  download_pull_requests_path: course_pull_requests_path(@course, :format => "csv"),
+                          },
+                          prerender: false) %>
+      <br/>
+    <% end %>
   <% end %>
   <%= yield %>
 <% end %>

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -215,8 +215,6 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
       post course_join_path(course_id: @course.id)
 
     end
-    assert_redirected_to courses_url
-    assert_equal @enroll_success_flash_notice, flash[:notice]
   end
 
   test "user can join class if roster student exists" do
@@ -227,8 +225,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     assert_difference('@user.roster_students.count', 1) do
       post course_join_path(course_id: @course.id)
     end
-    assert_redirected_to courses_url
-    assert_equal @enroll_success_flash_notice, flash[:notice]
+   
   end
 
 
@@ -244,9 +241,6 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     assert_difference('user.roster_students.count', 1) do
       post course_join_path(course_id: course.id)
     end
-    assert_redirected_to courses_url
-    enroll_success_flash_notice = %Q[You were successfully invited to #{course.name}! View and accept your invitation <a href="https://github.com/orgs/#{course.course_organization}/invitation">here</a>.]
-    assert_equal enroll_success_flash_notice, flash[:notice]
   end
 
   test "roster student can NOT join class if NOT on class roster" do

--- a/test/javascript/components/Course/JoinPage.test.js
+++ b/test/javascript/components/Course/JoinPage.test.js
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import '@testing-library/jest-dom/extend-expect';
+import JoinPage from "../../../../app/javascript/components/Course/JoinPage"
+import React from 'react';
+
+
+describe("JoinPage tests", () => {
+  
+  test("renders without crashing for empty table any logged in user", () => {
+
+    const course = {
+        course_organization : "ucsb-cs156-s22"
+    }
+    const { getByText } = render(
+          <JoinPage course={course} />
+    );
+
+    expect(getByText("Your Next Step")).toBeInTheDocument();
+  });
+
+});


### PR DESCRIPTION
In this PR added a new join page instead of a alert to accept the invitation when joining a course for a student.
Closes #503 

# Screenshots

Before, when you join a course, you get this very subtle alert at the top of the screen, which is easy to miss, and many students don't read it.

<img width="711" alt="image" src="https://user-images.githubusercontent.com/1119017/176964591-445fce0f-92d2-44c1-a445-237c03a1b87b.png">

After: when you join a course, you get this page, which, we hope will be a lot more noticable, and student will know what they need to do next.

![image](https://user-images.githubusercontent.com/72825220/176951629-6c3535f4-1b4e-4850-bb7c-12a2274f0e37.png)
