### PR TITLE
kz-set redirect to home page rather than courses page on error when joining a course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -88,7 +88,7 @@ class CoursesController < ApplicationController
     roster_student = cross_check_user_emails_with_class(course)
     if roster_student.nil?
       message = 'Your email did not match the email of any student on the course roster. Please check that your github email is correctly configured to match your school email and that you have verified your email address. '
-      return redirect_to courses_path, alert: message
+      return redirect_to root_path, alert: message
     end
 
     begin
@@ -98,7 +98,7 @@ class CoursesController < ApplicationController
        redirect_to courses_path, notice: %Q[You were successfully invited to #{course.name}! View and accept your invitation <a href="https://github.com/orgs/#{course.course_organization}/invitation">here</a>.]
     rescue Exception => e
       message = "Unable to invite #{current_user.username} to #{course.course_organization}; check whether #{ENV['MACHINE_USER_NAME']} has admin permission on that org.   Error: #{e.message}"
-      redirect_to courses_path, alert: message
+      redirect_to root_path, alert: message
     end
   end
 

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -261,7 +261,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    assert_redirected_to courses_url
+    assert_redirected_to root_url
     assert_equal "Your email did not match the email of any student on the course roster. Please check that your github email is correctly configured to match your school email and that you have verified your email address. ", flash[:alert]
 
   end


### PR DESCRIPTION
Closes #504 

Fixed issue when user tries to join a course and is not successful, redirect them to the home page, not the courses page.

