### PR TITLE
pc - add test coverage calculation to project using simplecov gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,3 +127,5 @@ gem 'flipper-ui'
 gem 'flipper-active_record'
 
 gem 'zlib'
+
+gem 'simplecov', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    docile (1.4.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -285,6 +286,12 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     slack-ruby-bot (0.16.0)
       hashie
       slack-ruby-client (>= 0.14.0)
@@ -387,6 +394,7 @@ DEPENDENCIES
   roo (~> 2.7.0)
   sass-rails (~> 5.0)
   selenium-webdriver
+  simplecov
   slack-ruby-bot
   spring
   spring-watcher-listen (~> 2.0.0)
@@ -403,4 +411,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.3.13
+   2.3.16

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,11 @@
 #!/usr/bin/env ruby
+
+if ENV['RAILS_ENV'] == 'test'
+  require 'simplecov'
+  SimpleCov.start 'rails'
+  puts "required simplecov"
+end
+
 begin
   load File.expand_path('../spring', __FILE__)
 rescue LoadError => e

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,8 @@
 Rails.env = 'test'
 
+require 'simplecov'
+SimpleCov.start
+
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 


### PR DESCRIPTION
Closes #520 

In this PR, we add simplecov, a gem for calculating test coverage for the Rails app.

Coverage is calculated automatically each time we run `rake test`; there is no need for a separate command.

The test coverage is reported by a message such as this one at the end of the output from `rake test`:

```
Coverage report generated for Minitest to /Users/pconrad/github/brownfield-team/anacapa-github-linker/coverage. 1715 / 2397 LOC (71.55%) covered.
```

You can also open the file `./coverage/index.html` in a web browser to see a more detailed report, e.g.

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/1119017/179309474-a377c8ff-81e9-4078-9fcf-368b6ec12ad9.png">

Drilling into a file shows the details of lines covered or not covered using colors:

<img width="1319" alt="image" src="https://user-images.githubusercontent.com/1119017/179309515-193a1e13-afd2-47c4-ac0c-145b64319abf.png">
